### PR TITLE
class Textile not loading; use \Netcarver\Textile\Parser instead

### DIFF
--- a/zem_tpl.php
+++ b/zem_tpl.php
@@ -53,21 +53,26 @@ function compile_plugin($file='') {
 
     // This is for bc; and for help that needs to use it.
     @include('classTextile.php');
-
-    if (defined('txpath')) {
+    if (class_exists('Textile')) {
+        $textile = new Textile();
+        $plugin['help'] = $textile->TextileThis($plugin['help']);
+    } elseif (defined('txpath')) {
         global $trace;
-
+        
+        include txpath.'/lib/txplib_misc.php';
         include txpath.'/lib/class.trace.php';
         include txpath.'/vendors/Textpattern/Loader.php';
 
         $trace = new Trace();
+        $loader = new \Textpattern\Loader(txpath.'/vendors');
+        $loader->register();
         $loader = new \Textpattern\Loader(txpath.'/lib');
         $loader->register();
-    }
-
-    if (class_exists('Textile')) {
-        $textile = new Textile();
-        $plugin['help'] = $textile->TextileThis($plugin['help']);
+        
+        if (class_exists('Netcarver\\Textile\\Parser')) {
+            $textile = new \Netcarver\Textile\Parser();
+            $plugin['help'] = $textile->textileThis($plugin['help']);
+        }
     }
 
     $plugin['md5'] = md5( $plugin['code'] );


### PR DESCRIPTION
I don't know enough about the autoloader to know why class Textile isn't loading, but it isn't. The template "worked" because `plugin_verify()` does the Textile parsing on install. (And now I see I could have used \Textpattern\Textile\Parser instead of \Netcarver\Textile\Parser, but no diff in this case.)